### PR TITLE
Add support for multi-line imports

### DIFF
--- a/plugin/es6-unused-imports.vim
+++ b/plugin/es6-unused-imports.vim
@@ -50,7 +50,7 @@ function! s:highlight_unused_imports()
     endif
     let import_str = matchstr(line, '\v(^\s*([\/]{2,})?\s*import\zs.*\zefrom)')
     " delete all curly braces, commas, and '<keyword or asterisk> as '
-    let import_str = substitute(import_str, '{\|}\|,\|\(\k\|\*\)\+\s\+as\s\+', '', 'g')
+    let import_str = substitute(import_str, '{\|}\|,\|\n\|\(\k\|\*\)\+\s\+as\s\+', '', 'g')
     let sp = split(import_str)
 
     for word in sp


### PR DESCRIPTION
This PR includes a minor change to the match regex to add support for multi-line imports.

```javascript
// imports such as this are now supported
import {
    foo,
    bar,
    baz,
    qux,
    quux,
    quuz,
} from 'corge';
```

@kathgironpe Perhaps of interest as you've forked the repo as well.